### PR TITLE
Adding DB::GetCurrentWalFile() API as a repliction/backup helper

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -163,6 +163,10 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
   return wal_manager_.GetSortedWalFiles(files);
 }
 
+Status DBImpl::GetCurrentWalFile(LogFile** current_log_file) {
+  return wal_manager_.GetWalFile(logfile_number_, current_log_file);
+}
+
 }
 
 #endif  // ROCKSDB_LITE

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -338,6 +338,7 @@ class DBImpl : public DB {
                               uint64_t* manifest_file_size,
                               bool flush_memtable = true) override;
   virtual Status GetSortedWalFiles(VectorLogPtr& files) override;
+  virtual Status GetCurrentWalFile(LogFile** current_log_file) override;
 
   virtual Status GetUpdatesSince(
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2790,6 +2790,10 @@ class ModelDB : public DB {
     return Status::OK();
   }
 
+  Status GetCurrentWalFile(LogFile** /*current_log_file*/) override {
+    return Status::OK();
+  }
+
   Status DeleteFile(std::string /*name*/) override { return Status::OK(); }
 
   Status GetUpdatesSince(

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -569,6 +569,58 @@ TEST_F(DBWALTest, GetSortedWalFiles) {
   } while (ChangeWalOptions());
 }
 
+TEST_F(DBWALTest, GetCurrentWalFile) {
+  do {
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+
+    LogFile *log_file;
+    ASSERT_OK(dbfull()->GetCurrentWalFile(&log_file));
+
+    // nothing has been written to the log yet
+    ASSERT_EQ(log_file->StartSequence(), 0);
+    ASSERT_EQ(log_file->SizeFileBytes(), 0);
+    ASSERT_EQ(log_file->Type(), kAliveLogFile);
+    ASSERT_GT(log_file->LogNumber(), 0);
+
+    delete log_file;
+
+    // add some data and verify that the log actually moves
+    ASSERT_OK(Put(0, "foo", "v1"));
+    ASSERT_OK(Put(0, "foo2", "v2"));
+    ASSERT_OK(Put(0, "foo3", "v3"));
+
+    ASSERT_OK(dbfull()->GetCurrentWalFile(&log_file));
+
+    ASSERT_EQ(log_file->StartSequence(), 1);
+    ASSERT_GT(log_file->SizeFileBytes(), 0);
+    ASSERT_EQ(log_file->Type(), kAliveLogFile);
+    ASSERT_GT(log_file->LogNumber(), 0);
+
+    delete log_file;
+
+    // force log files to cycle and add some more data
+
+    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
+    for (int i = 0; i < 10; i++) {
+      ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
+    }
+
+    ASSERT_OK(Put(0, "foo4", "v4"));
+    ASSERT_OK(Put(0, "foo5", "v5"));
+    ASSERT_OK(Put(0, "foo6", "v6"));
+
+    ASSERT_OK(dbfull()->GetCurrentWalFile(&log_file));
+
+    ASSERT_GT(log_file->StartSequence(), 1);
+    ASSERT_GT(log_file->SizeFileBytes(), 0);
+    ASSERT_EQ(log_file->Type(), kAliveLogFile);
+    ASSERT_GT(log_file->LogNumber(), 0);
+
+    delete log_file;
+
+  } while (ChangeWalOptions());
+}
+
 TEST_F(DBWALTest, RecoveryWithLogDataForSomeCFs) {
   // Test for regression of WAL cleanup missing files that don't contain data
   // for every column family.

--- a/db/wal_manager.h
+++ b/db/wal_manager.h
@@ -59,6 +59,8 @@ class WalManager {
 
   Status DeleteFile(const std::string& fname, uint64_t number);
 
+  Status GetWalFile(uint64_t number, LogFile** log_file);
+
   Status TEST_ReadFirstRecord(const WalFileType type, const uint64_t number,
                               SequenceNumber* sequence) {
     return ReadFirstRecord(type, number, sequence);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1123,6 +1123,13 @@ class DB {
   // Retrieve the sorted list of all wal files with earliest file first
   virtual Status GetSortedWalFiles(VectorLogPtr& files) = 0;
 
+  // Retrieve information about the current wal file
+  //
+  // This should only be used as an optimization for opportunistically looking
+  // up the current log. The log might have rolled after this call in which case
+  // the current_log_file would not point to the current or even live log file.
+  virtual Status GetCurrentWalFile(LogFile** current_log_file) = 0;
+
   // Note: this API is not yet consistent with WritePrepared transactions.
   // Sets iter to an iterator that is positioned at a write-batch containing
   // seq_number. If the sequence number is non existent, it returns an iterator

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -371,6 +371,10 @@ class StackableDB : public DB {
     return db_->GetSortedWalFiles(files);
   }
 
+  virtual Status GetCurrentWalFile(LogFile** current_log_file) override {
+    return db_->GetCurrentWalFile(current_log_file);
+  }
+
   virtual Status DeleteFile(std::string name) override {
     return db_->DeleteFile(name);
   }


### PR DESCRIPTION
Adding a light weight API to get last WAL file name, start sequence and size. Meant to be used as a helper for backup/restore tooling. 